### PR TITLE
Use the title from the config in the window.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ pub const MIN_WINDOW_SIZE: (u32, u32) = (20, 20);
 /// Used to store the configuration required to run the Mage game engine.
 pub struct Config {
     /// The title of the window.
-    pub title: String,
+    pub title: Option<String>,
 
     /// The size of the window in characters.
     ///
@@ -26,7 +26,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            title: "Mage Game".to_string(),
+            title: None,
             inner_size: (800, 600),
             font: Font::Default,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ where
 
     let window = WindowBuilder::new()
         .with_inner_size(PhysicalSize::new(width, height))
-        .with_title("Mage Game")
+        .with_title(config.title.unwrap_or("Mage Game".to_string()))
         .with_min_inner_size(PhysicalSize::new(
             MIN_WINDOW_SIZE.0 * font_data.char_width,
             MIN_WINDOW_SIZE.1 * font_data.char_height,


### PR DESCRIPTION
Hello,

This is a small change, it seems that the window title is not currently used in the Config struct. I put it into the window's title. 